### PR TITLE
Correção imagem Cristina Cairo

### DIFF
--- a/perfil/cristina-cairo.html
+++ b/perfil/cristina-cairo.html
@@ -80,9 +80,12 @@
             <p>Cristina Cairo é formada em Educação Física pela Faculdade Osec(Fefisa) e bacharel em Psicologia pela Universidade FMU, com várias especializações em Medicina Chinesa e Egipcia, (possui descendência egípcia). Estuda Filosofia Oriental desde os treze anos. É formada em Parapsicologia pela AMORC. Fez cursos na Sinapsi e na Print, escolas de programação neuro-linguística.</p>
             <p>Atuou na emissora SBT de 1982 a 1999 como atriz e apresentadora. De 1995 a 1997 foi produtora e apresentadora dos programas “Energia de Mulher” e “Mexa-se” na rede Mulher de Televisão (hoje, REDE TV). Coordenou e apresentou o programa “Linguagem do Corpo” em 2001 no canal São Paulo, da TVA, e apresenta o mesmo programa pela Radio Mundial (95,7 FM – São Paulo – todas as quintas-feiras, às 16:00 horas).</p>
         </div>
-        <div class="fotona">
-            <img src="img/cris-cairo.jpg" alt="Cris Cairo segurando um cristal">
+        <div class="fotona" style="background-image: url(img/cris-cairo.jpg);">
+            <div class="sr-only">Cris Cairo segurando um cristal</div>
             <style>
+                .sr-only {
+                    visibility: hidden;
+                }
                 .fotona > div:nth-child(2){
                     position: absolute;
                 }


### PR DESCRIPTION
Oi Cintia,

Sobre a sua imagem no artigo, como você colocou como imagem de fundo, eu optei por tirar o <img> e colocar como fundo também. Adicionei a <div class="sr-only"> pra deixar a sua descrição de imagem (sr-only significa 'screen reader only' e é uma classe usada no bootrstap). No <style>, coloquei ele como visibility: hidden;

A diferença entre o visibility hidden e o display none é que o primeiro ainda ocupa um espaço no HTML, enquanto o segundo não.

Se tiver dúvida, fala comigo no whatsapp!

Bjss